### PR TITLE
Update OpenAI dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -69,7 +69,7 @@ multidict==6.6.3
 mypy_extensions==1.1.0
 narwhals==1.48.0
 numpy==2.3.1
-openai==1.58.1
+openai>=1.86.0,<2.0
 openpyxl==3.1.5
 ordered-set==4.1.0
 orjson==3.11.0


### PR DESCRIPTION
## Summary
- bump OpenAI version in backend requirements

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohappyeyeballs)*

------
https://chatgpt.com/codex/tasks/task_e_6883a0ca006c8320a6cf07c0e1db8288